### PR TITLE
Make @babel/runtime a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,9 +90,11 @@
   "peerDependencies": {
     "redux-saga": "1.x"
   },
+  "dependencies": {
+    "@babel/runtime": "7.3.1",
+  },
   "devDependencies": {
     "@babel/core": "7.2.2",
-    "@babel/runtime": "7.3.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "24.1.0",


### PR DESCRIPTION
> This is meant to be used as a runtime `dependency` along with the Babel plugin `@babel/plugin-transform-runtime`.

https://babeljs.io/docs/en/babel-runtime#usage